### PR TITLE
Fix/lowercase user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 
 
+## [0.1.2] - 2023-03-13
+
+### Fix
+
+- Fix: Usernames should always be lowercase, even if fetched from Azure as not mixedcase principal name.
+
 ## [0.1.1] - 2022-11-14
 
 ### Changed

--- a/inviter/room_structure.py
+++ b/inviter/room_structure.py
@@ -63,7 +63,7 @@ class MXID:
     homeserver: str = None
 
     def __init__(self, username: str, homeserver: str):
-        self.username = username
+        self.username = username.lower()
         self.homeserver = homeserver
 
     @classmethod
@@ -73,7 +73,7 @@ class MXID:
         :param user_id: A string representing a MXID (e.g. @name:homeserver.tld)
         :return: Newly created MXID object
         """
-        username: str = user_id.split(':', 1)[0].replace('@', '')
+        username: str = user_id.split(':', 1)[0].replace('@', '').lower()
         homeserver: str = user_id.split(':', 1)[1]
         return cls(username, homeserver)
 

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.2.0
 id: de.in4md-service.inviterbot
-version: 0.1.1
+version: 0.1.2
 license: GPLv3
 modules:
  - inviter


### PR DESCRIPTION
Fix: Usernames should always be lowercase, even if fetched from Azure as not mixedcase principal name.