### PR TITLE
Add a config option to select which attribute is used as a username

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -29,6 +29,7 @@ ldap:
   base_dn_groups: "cn=groups,cn=accounts,dc=example,dc=com"
 
   user_filter:  "(!(memberof=cn=company_employees,cn=groups,cn=accounts,dc=example,dc=com))"
+  username_attribute: "uid"
 
 # Room for bot-administration. Commands are only accepted inside this room.
 administration_room: ""

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.2.0
 id: de.in4md-service.inviterbot
-version: 0.1.5
+version: 0.1.6
 license: GPLv3
 modules:
  - inviter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mautrix~=0.15.8
+mautrix~=0.20.3
 pytz~=2022.1
-maubot~=0.3.1
+maubot~=0.4.2
 ldap3~=2.9.1
 azure-identity~=1.8.0
 msgraph-core~=0.2.2


### PR DESCRIPTION
I was setting this up with authentik. But it uses random uids, and instead sends the readable username in the `cn` attribute. So, I've added this config option to make that configurable.

I also updated deps due to this: https://github.com/MagicStack/asyncpg/issues/899